### PR TITLE
Attribute imageUrl added in model, migration and in seeds

### DIFF
--- a/migrations/20200702193300-migration-imageurl.js
+++ b/migrations/20200702193300-migration-imageurl.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+      "indoorskiplaces",
+      "imageUrl",
+      { type: Sequelize.TEXT },
+      {}
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("indoorskiplaces", "imageUrl", {});
+  },
+};

--- a/models/indoorskiplace.js
+++ b/models/indoorskiplace.js
@@ -25,6 +25,10 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: false,
       },
+      imageUrl: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
     },
     {}
   );

--- a/seeders/20200701113335-some-indoorskiplaces.js
+++ b/seeders/20200701113335-some-indoorskiplaces.js
@@ -12,6 +12,8 @@ module.exports = {
           priceAveragePerHour: 15,
           rating: 5,
           facility: "indoor dome",
+          imageUrl:
+            "https://www.dagjeweg.nl/img/afb/0/2/7/r0-0d-300-225-1cf-kind_kinderpiste_snowplanet-1556270036.jpeg",
           createdAt: new Date(),
           updatedAt: new Date(),
         },
@@ -22,6 +24,8 @@ module.exports = {
           priceAveragePerHour: 20,
           rating: 5,
           facility: "indoor dome",
+          imageUrl:
+            "https://img5.onthesnow.com/image/la/14/indoor_snowpark_snowworld_landgraaf_netherlands_1_144862.jpg",
           createdAt: new Date(),
           updatedAt: new Date(),
         },
@@ -32,6 +36,8 @@ module.exports = {
           priceAveragePerHour: 13,
           rating: 4,
           facility: "ski simulator",
+          imageUrl:
+            "https://skidiscovery.nl/wp-content/uploads/2017/04/SkiDiscovery-46Edit-545x380.jpg",
           createdAt: new Date(),
           updatedAt: new Date(),
         },


### PR DESCRIPTION
## What's in this pull request

To display an image per indoorskiplace, the attribute imageUrl needed to be added.
So in the models it was manually added, then a migration file was made, and lastly, the seeds were updated